### PR TITLE
oauth2 token url for dropboxv2

### DIFF
--- a/lib/dropbox_server.js
+++ b/lib/dropbox_server.js
@@ -38,7 +38,7 @@ var getTokens = function (query) {
     var redirectUri = OAuth._redirectUri('dropbox', config, {}, {secure: true}).replace('?close', '?close=true');
     console.log(redirectUri);
     response = HTTP.post(
-      "https://api.dropbox.com/1/oauth2/token", {params: {
+      "https://api.dropbox.com/oauth2/token", {params: {
         code: query.code,
         client_id: config.clientId,
         client_secret: OAuth.openSecret(config.secret),


### PR DESCRIPTION
As described in https://www.dropbox.com/developers/reference/migration-guide, the oauth2 token url is changed to https://api.dropbox.com/oauth2/token for dropbox v2 api. v1 will be deprecated today